### PR TITLE
Express integration

### DIFF
--- a/examples/server.js
+++ b/examples/server.js
@@ -1,6 +1,12 @@
 const WebTCP = require("../src");
+const express = require("express");
+const enableWebsockets = require("express-ws");
 
-const server = new WebTCP({
-  debug: true
-});
-server.install();
+const PORT = 9999;
+
+const app = express();
+enableWebsockets(app);
+
+const tcp = new WebTCP({ debug: true });
+app.ws("/", (ws, req) => tcp.handle(ws, req));
+app.listen(PORT, () => console.log(`webtcp Example running on ws port ${PORT}!`))

--- a/examples/server.js
+++ b/examples/server.js
@@ -1,4 +1,4 @@
-const WebTCP = require("../src");
+const webtcp = require("../src");
 const express = require("express");
 const enableWebsockets = require("express-ws");
 
@@ -7,6 +7,5 @@ const PORT = 9999;
 const app = express();
 enableWebsockets(app);
 
-const tcp = new WebTCP({ debug: true });
-app.ws("/", (ws, req) => tcp.handle(ws, req));
+app.ws("/", webtcp({ debug: true }));
 app.listen(PORT, () => console.log(`webtcp Example running on ws port ${PORT}!`))

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,10 +4,433 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "accepts": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "dev": true,
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
+    },
+    "array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+    },
+    "body-parser": {
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      }
+    },
+    "bytes": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg=",
+      "dev": true
+    },
+    "content-disposition": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ=",
+      "dev": true
+    },
+    "content-type": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
+      "dev": true
+    },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=",
+      "dev": true
+    },
+    "cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "dev": true
+    },
+    "debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
+      "requires": {
+        "ms": "2.0.0"
+      }
+    },
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
+      "dev": true
+    },
+    "destroy": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA=",
+      "dev": true
+    },
+    "ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "dev": true
+    },
+    "encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "dev": true
+    },
+    "escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "dev": true
+    },
+    "etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "dev": true
+    },
+    "express": {
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "dev": true,
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      }
+    },
+    "express-ws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/express-ws/-/express-ws-4.0.0.tgz",
+      "integrity": "sha512-KEyUw8AwRET2iFjFsI1EJQrJ/fHeGiJtgpYgEWG3yDv4l/To/m3a2GaYfeGyB3lsWdvbesjF5XCMx+SVBgAAYw==",
+      "requires": {
+        "ws": "^5.2.0"
+      }
+    },
+    "finalhandler": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      }
+    },
+    "forwarded": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ=",
+      "dev": true
+    },
+    "fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "dev": true
+    },
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "dev": true,
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+      "dev": true
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "ipaddr.js": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs=",
+      "dev": true
+    },
+    "media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "dev": true
+    },
+    "merge-descriptors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "dev": true
+    },
+    "methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "dev": true
+    },
+    "mime": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==",
+      "dev": true
+    },
+    "mime-db": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
+    },
+    "mime-types": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
+      "requires": {
+        "mime-db": "~1.33.0"
+      }
+    },
+    "ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
+    },
+    "negotiator": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk=",
+      "dev": true
+    },
+    "on-finished": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "dev": true,
+      "requires": {
+        "ee-first": "1.1.1"
+      }
+    },
+    "parseurl": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=",
+      "dev": true
+    },
+    "path-to-regexp": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "dev": true
+    },
+    "proxy-addr": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha512-jQTChiCJteusULxjBp8+jftSQE5Obdl3k4cnmLA6WXtK6XFuWRnvVL7aCiBqaLPM8c4ph0S4tKna8XvmIwEnXQ==",
+      "dev": true,
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
+    },
+    "qs": {
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
+    },
+    "range-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "dev": true
+    },
+    "raw-body": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "dev": true,
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+          "dev": true
+        },
+        "http-errors": {
+          "version": "1.6.2",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "dev": true,
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": ">= 1.3.1 < 2"
+          }
+        },
+        "setprototypeof": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+          "dev": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
+    },
+    "send": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "dev": true,
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      }
+    },
+    "serve-static": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "dev": true,
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
+    },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ==",
+      "dev": true
+    },
+    "statuses": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+      "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew==",
+      "dev": true
+    },
+    "type-is": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
+      "dev": true,
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
+    },
+    "unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "dev": true
+    },
+    "utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "dev": true
+    },
+    "vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "dev": true
     },
     "ws": {
       "version": "5.2.0",

--- a/package.json
+++ b/package.json
@@ -12,11 +12,12 @@
     "type": "git",
     "url": "git://github.com/PatrickSachs/webtcp.git"
   },
-  "dependencies": {
-    "ws": "^5.2.0"
-  },
   "scripts": {
     "example": "node ./examples/server"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "express-ws": "^4.0.0",
+    "express": "^4.16.3"
+  }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -34,7 +34,6 @@ const defaultOptions = {
     initialDelay: 0
   }
 }
-const SOCKET = "socket";
 
 class WebTCP {
   constructor(options = {}) {
@@ -193,4 +192,9 @@ class WebTCP {
   }
 }
 
-module.exports = WebTCP;
+const install = options => {
+  const tcp = new WebTCP(options);
+  return (ws, req) => tcp.handle(ws, req);
+}
+
+module.exports = install;

--- a/src/index.js
+++ b/src/index.js
@@ -1,14 +1,9 @@
 const { Socket } = require("net");
-const WebSocket = require("ws");
 
 const defaultOptions = {
   // The options for this webtcp server instance
   debug: false,
   mayConnect: () => true,
-  // The options for the websocket server - https://github.com/websockets/ws/blob/master/doc/ws.md#new-websocketserveroptions-callback
-  socketOptions: {
-    port: 9999
-  },
   // The default options for the TCP socket
   defaultTcpOptions: {
     host: "localhost",
@@ -172,7 +167,17 @@ class WebTCP {
     }
   }
 
-  // todo: allow express integration
+  handle(ws, req) {
+    const connection = {
+      write: data => ws.send(JSON.stringify(data)),
+      isOpen: () => ws.readyState === WebSocket.OPEN
+    };
+    console.log("handle-ws", ws, req);
+    ws.on('message', message => this.dispatch(connection, message));
+    ws.on("close", () => this.close(connection));
+  }
+
+  /*// todo: allow express integration
   install() {
     this.websocket = new WebSocket.Server(this.options.socketOptions);
     this.websocket.on('connection', ws => {
@@ -185,7 +190,7 @@ class WebTCP {
       ws.on("close", () => this.close(connection));
     });
     this.options.debug && console.log("[webtcp] Listening", this.options.socketOptions);
-  }
+  }*/
 }
 
 module.exports = WebTCP;

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,28 @@
 const { Socket } = require("net");
 
+/**
+ * The numeric ready states of the WebSocket.
+ */
+const READY_STATE = {
+  CONNECTING: 0,
+  OPEN: 1,
+  CLOSING: 2,
+  CLOSED_: 3
+}
+
 const defaultOptions = {
   // The options for this webtcp server instance
   debug: false,
   mayConnect: () => true,
+  // Creates the connection/session object if you are using a non-default WebSocket implementation.
+  createConnection: (ws, _req) => ({
+    // Sends a JSON object over the WebSocket.
+    send: data => ws.send(JSON.stringify(data)),
+    // Checks if the socket is open. If this returns true, the server assumes that calling send will work.
+    isOpen: () => ws.readyState === READY_STATE.OPEN,
+    // Placeholder for the TCP socket. Simply set this to null unless you need to get really fancy.
+    socket: null
+  }),
   // The default options for the TCP socket
   defaultTcpOptions: {
     host: "localhost",
@@ -15,7 +34,7 @@ const defaultOptions = {
     initialDelay: 0
   }
 }
-const SOCKET = Symbol("webtcp-socket");
+const SOCKET = "socket";
 
 class WebTCP {
   constructor(options = {}) {
@@ -31,16 +50,16 @@ class WebTCP {
   }
 
   close(connection) {
-    if (connection[SOCKET]) {
+    if (connection.socket) {
       this.options.debug && console.log("[webtcp] Closing connection");
-      connection[SOCKET].end();
+      connection.socket.end();
     }
   }
 
   dispatch(connection, message) {
     try {
       const json = JSON.parse(message);
-      this.options.debug && console.log("[webtcp] Got message", json, "has socket?", !!connection[SOCKET]);
+      this.options.debug && console.log("[webtcp] Got message", json, "has socket?", !!connection.socket);
       switch (json.type) {
         case "connect": {
           this.dispatchConnect(connection, json);
@@ -58,7 +77,7 @@ class WebTCP {
     }
     catch (e) {
       console.log("error", e);
-      connection.write({
+      connection.send({
         type: "error",
         error: e.message
       });
@@ -66,10 +85,10 @@ class WebTCP {
   }
 
   dispatchClose(connection, json) {
-    if (connection[SOCKET]) {
+    if (connection.socket) {
       this.close(connection);
     } else {
-      connection.write({
+      connection.send({
         type: "error",
         error: "not connected"
       });
@@ -77,20 +96,20 @@ class WebTCP {
   }
 
   dispatchData(connection, json) {
-    if (connection[SOCKET]) {
+    if (connection.socket) {
       if (json.payload !== undefined) {
         const payload = typeof json.payload === "string"
           ? json.payload
           : Uint8Array.from(json.payload);
-        connection[SOCKET].write(payload, this.options.encoding);
+        connection.socket.write(payload, this.options.encoding);
       } else {
-        connection.write({
+        connection.send({
           type: "error",
           error: "no payload"
         });
       }
     } else {
-      connection.write({
+      connection.send({
         type: "error",
         error: "not connected"
       });
@@ -98,13 +117,13 @@ class WebTCP {
   }
 
   dispatchConnect(connection, json) {
-    if (!connection[SOCKET]) {
+    if (!connection.socket) {
       const tcpOptions = {
         ...this.options.defaultTcpOptions,
         ...json
       }
       if (this.options.mayConnect({ host: tcpOptions.host, port: tcpOptions.port })) {
-        const socket = connection[SOCKET] = new Socket();
+        const socket = connection.socket = new Socket();
         socket.connect(tcpOptions.port, tcpOptions.host, () => {
           socket.setEncoding(tcpOptions.encoding);
           socket.setTimeout(tcpOptions.timeout);
@@ -113,19 +132,19 @@ class WebTCP {
         });
         socket.on("ready", () => {
           this.options.debug && console.log("[webtcp] Socket ready");
-          connection.write({ type: "connect" });
+          connection.send({ type: "connect" });
         });
         socket.on("end", () => {
           this.options.debug && console.log("[webtcp] Socket end");
           if (connection.isOpen()) {
-            connection.write({ type: "end" });
+            connection.send({ type: "end" });
           }
         });
         socket.on("close", hadError => {
-          delete connection[SOCKET];
+          connection.socket = null;
           this.options.debug && console.log("[webtcp] Socket closed", "error?", hadError);
           if (connection.isOpen()) {
-            connection.write({
+            connection.send({
               type: "close",
               hadError
             });
@@ -134,12 +153,12 @@ class WebTCP {
         socket.on("timeout", () => {
           this.options.debug && console.log("[webtcp] Socket timeout");
           socket.destroy();
-          connection.write({ type: "timeout" });
+          connection.send({ type: "timeout" });
         });
         socket.on("error", (error) => {
           this.options.debug && console.log("[webtcp] Socket error", error);
           if (connection.isOpen()) {
-            connection.write({
+            connection.send({
               type: "error",
               error: error.errno
             });
@@ -147,20 +166,20 @@ class WebTCP {
         });
         socket.on("data", payload => {
           this.options.debug && console.log("[webtcp] Socket data", payload);
-          connection.write({
+          connection.send({
             type: "data",
             // todo: forward binary data as array!
             payload: ("string" === typeof payload) ? payload : payload.toString(tcpOptions.encoding)
           });
         });
       } else {
-        connection.write({
+        connection.send({
           type: "error",
           error: "not allowed connection"
         });
       }
     } else {
-      connection.write({
+      connection.send({
         type: "error",
         error: "already connected"
       });
@@ -168,29 +187,10 @@ class WebTCP {
   }
 
   handle(ws, req) {
-    const connection = {
-      write: data => ws.send(JSON.stringify(data)),
-      isOpen: () => ws.readyState === WebSocket.OPEN
-    };
-    console.log("handle-ws", ws, req);
+    const connection = this.options.createConnection(ws, req);
     ws.on('message', message => this.dispatch(connection, message));
     ws.on("close", () => this.close(connection));
   }
-
-  /*// todo: allow express integration
-  install() {
-    this.websocket = new WebSocket.Server(this.options.socketOptions);
-    this.websocket.on('connection', ws => {
-      const connection = {
-        write: data => ws.send(JSON.stringify(data)),
-        isOpen: () => ws.readyState === WebSocket.OPEN
-      };
-      console.log("readyState", ws.readyState)
-      ws.on('message', message => this.dispatch(connection, message));
-      ws.on("close", () => this.close(connection));
-    });
-    this.options.debug && console.log("[webtcp] Listening", this.options.socketOptions);
-  }*/
 }
 
 module.exports = WebTCP;


### PR DESCRIPTION
I didn't like the fact that WebTCP uses a port just for itself. 

WebTCP is now able to integrate into express using express-ws seamlessly, and probably into other ws implementations as well if you tinker with the `options.createConnection(ws, req)` function.